### PR TITLE
Add support for Enchantment Descriptions.

### DIFF
--- a/src/main/resources/assets/curses/lang/en_us.json
+++ b/src/main/resources/assets/curses/lang/en_us.json
@@ -3,7 +3,8 @@
   "enchantment.curses.poverty.desc": "Entities won't drop loot when killed.",
 
   "enchantment.curses.fragility": "Curse of Fragility",
-  "enchantment.curses.fragility": "The item may rasndomly break.",
+  "enchantment.curses.fragility.desc": "The item may randomly break.",
+
 
   "enchantment.curses.instability": "Curse of Instability",
   "enchantment.curses.instability": "Causes an explosion when in contact with fire.",

--- a/src/main/resources/assets/curses/lang/en_us.json
+++ b/src/main/resources/assets/curses/lang/en_us.json
@@ -1,9 +1,13 @@
 {
   "enchantment.curses.poverty": "Curse of Poverty",
+  "enchantment.curses.poverty.desc": "Entities won't drop loot when killed.",
 
   "enchantment.curses.fragility": "Curse of Fragility",
+  "enchantment.curses.fragility": "The item may rasndomly break.",
 
   "enchantment.curses.instability": "Curse of Instability",
+  "enchantment.curses.instability": "Causes an explosion when in contact with fire.",
 
-  "enchantment.curses.death": "Curse of Death"
+  "enchantment.curses.death": "Curse of Death",
+  "enchantment.curses.death": "Causes the user to instantly die when equipped."
 }

--- a/src/main/resources/assets/curses/lang/en_us.json
+++ b/src/main/resources/assets/curses/lang/en_us.json
@@ -11,5 +11,6 @@
 
 
   "enchantment.curses.death": "Curse of Death",
-  "enchantment.curses.death": "Causes the user to instantly die when equipped."
+  "enchantment.curses.death.desc": "Causes the user to instantly die when equipped."
+
 }

--- a/src/main/resources/assets/curses/lang/en_us.json
+++ b/src/main/resources/assets/curses/lang/en_us.json
@@ -7,7 +7,8 @@
 
 
   "enchantment.curses.instability": "Curse of Instability",
-  "enchantment.curses.instability": "Causes an explosion when in contact with fire.",
+  "enchantment.curses.instability.desc": "Causes an explosion when in contact with fire.",
+
 
   "enchantment.curses.death": "Curse of Death",
   "enchantment.curses.death": "Causes the user to instantly die when equipped."


### PR DESCRIPTION
This PR adds support for mods that display enchantment descriptions in game, such as the [Enchantment Descriptions](https://www.curseforge.com/minecraft/mc-mods/enchantment-descriptions) mod.